### PR TITLE
[#24] refactor/프로필 수정 조건 로직 서비스 계층으로 이동

### DIFF
--- a/src/main/java/com/example/feeda/domain/profile/entity/Profile.java
+++ b/src/main/java/com/example/feeda/domain/profile/entity/Profile.java
@@ -50,14 +50,8 @@ public class Profile extends BaseEntity {
     }
 
     public void updateProfile(String nickname, Date birth, String bio) {
-        if (nickname != null) {
             this.nickname = nickname;
-        }
-        if (birth != null) {
             this.birth = birth;
-        }
-        if (bio != null) {
             this.bio = bio;
         }
     }
-}

--- a/src/main/java/com/example/feeda/domain/profile/service/ProfileService.java
+++ b/src/main/java/com/example/feeda/domain/profile/service/ProfileService.java
@@ -103,11 +103,13 @@ public class ProfileService {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "수정 권한이 없습니다.");
         }
 
-        profile.updateProfile(
-                requestDto.getNickname(),
-                requestDto.getBirth(),
-                requestDto.getBio()
-        );
+        if (requestDto.getNickname() != null || requestDto.getBirth() != null || requestDto.getBio() != null) {
+            profile.updateProfile(
+                    requestDto.getNickname(),
+                    requestDto.getBirth(),
+                    requestDto.getBio()
+            );
+        }
 
         profileRepository.save(profile);
 


### PR DESCRIPTION
## 상세 내용

- Profile 엔티티 내부의 null 체크 로직을 ProfileService로 이동
- 
- requestDto에 변경 값이 존재할 때만 updateProfile() 호출되도록 개선
- 
- 엔티티의 책임을 축소하고, 서비스 계층에서 제어 흐름을 관리하도록 구조 변경

<br/>

## 주의 사항

- null 값만 넘어왔을 경우 updateProfile()이 호출되지 않음

<br/>