### PR TITLE
[#32] 팔로우 페이지네이션으로 변경

### DIFF
--- a/src/main/java/com/example/feeda/domain/follow/controller/FollowsController.java
+++ b/src/main/java/com/example/feeda/domain/follow/controller/FollowsController.java
@@ -2,19 +2,25 @@ package com.example.feeda.domain.follow.controller;
 
 import com.example.feeda.domain.follow.dto.FollowsResponseDto;
 import com.example.feeda.domain.follow.service.FollowsService;
-import com.example.feeda.domain.profile.dto.GetProfileResponseDto;
+import com.example.feeda.domain.profile.dto.ProfileListResponseDto;
 import com.example.feeda.security.jwt.JwtPayload;
-import java.util.List;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/follows")
@@ -39,30 +45,50 @@ public class FollowsController {
     }
 
     @GetMapping("/{profileId}/followings")
-    public List<GetProfileResponseDto> getFollowings(@PathVariable Long profileId,
+    public ProfileListResponseDto getFollowings(@PathVariable Long profileId,
+        @RequestParam(defaultValue = "1") @Min(1) Integer page,
+        @RequestParam(defaultValue = "10") @Min(5) Integer size,
         @AuthenticationPrincipal JwtPayload jwtPayload) {
 
-        return followsService.findFollowings(profileId, jwtPayload);
+        Pageable pageable = PageRequest
+            .of(page - 1, size, Direction.DESC, "createdAt");
+
+        return followsService.findFollowingsPage(profileId, jwtPayload, pageable);
     }
 
     @GetMapping("/{profileId}/followers")
-    public List<GetProfileResponseDto> getFollowers(@PathVariable Long profileId,
+    public ProfileListResponseDto getFollowers(@PathVariable Long profileId,
+        @RequestParam(defaultValue = "1") @Min(1) Integer page,
+        @RequestParam(defaultValue = "10") @Min(5) Integer size,
         @AuthenticationPrincipal JwtPayload jwtPayload) {
 
-        return followsService.findFollowers(profileId, jwtPayload);
+        Pageable pageable = PageRequest
+            .of(page - 1, size, Direction.DESC, "createdAt");
+
+        return followsService.findFollowersPage(profileId, jwtPayload, pageable);
     }
 
     @GetMapping("/followings")
-    public List<GetProfileResponseDto> getMyFollowings(
-        @AuthenticationPrincipal JwtPayload jwtPayload) {
+    public ProfileListResponseDto getMyFollowings(
+        @AuthenticationPrincipal JwtPayload jwtPayload,
+        @RequestParam(defaultValue = "1") @Min(1) Integer page,
+        @RequestParam(defaultValue = "10") @Min(5) Integer size) {
 
-        return followsService.findFollowings(jwtPayload.getProfileId(), jwtPayload);
+        Pageable pageable = PageRequest
+            .of(page - 1, size, Direction.DESC, "createdAt");
+
+        return followsService.findFollowingsPage(jwtPayload.getProfileId(), jwtPayload, pageable);
     }
 
     @GetMapping("/followers")
-    public List<GetProfileResponseDto> getMyFollowers(
-        @AuthenticationPrincipal JwtPayload jwtPayload) {
+    public ProfileListResponseDto getMyFollowers(
+        @AuthenticationPrincipal JwtPayload jwtPayload,
+        @RequestParam(defaultValue = "1") @Min(1) Integer page,
+        @RequestParam(defaultValue = "10") @Min(5) Integer size) {
 
-        return followsService.findFollowers(jwtPayload.getProfileId(), jwtPayload);
+        Pageable pageable = PageRequest
+            .of(page - 1, size, Direction.DESC, "createdAt");
+
+        return followsService.findFollowersPage(jwtPayload.getProfileId(), jwtPayload, pageable);
     }
 }

--- a/src/main/java/com/example/feeda/domain/follow/repository/FollowsRepository.java
+++ b/src/main/java/com/example/feeda/domain/follow/repository/FollowsRepository.java
@@ -2,8 +2,9 @@ package com.example.feeda.domain.follow.repository;
 
 import com.example.feeda.domain.follow.entity.Follows;
 import com.example.feeda.domain.profile.entity.Profile;
-import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,7 +13,7 @@ public interface FollowsRepository extends JpaRepository<Follows, Long> {
 
     Optional<Follows> findByFollowersAndFollowings(Profile followers, Profile followings);
 
-    List<Follows> findAllByFollowers_Id(Long followerId);
+    Page<Follows> findAllByFollowings_Id(Long followingsId, Pageable pageable);
 
-    List<Follows> findAllByFollowings_Id(Long followingId);
+    Page<Follows> findAllByFollowers_Id(Long followersId, Pageable pageable);
 }

--- a/src/main/java/com/example/feeda/domain/follow/service/FollowsService.java
+++ b/src/main/java/com/example/feeda/domain/follow/service/FollowsService.java
@@ -1,9 +1,9 @@
 package com.example.feeda.domain.follow.service;
 
 import com.example.feeda.domain.follow.dto.FollowsResponseDto;
-import com.example.feeda.domain.profile.dto.GetProfileResponseDto;
+import com.example.feeda.domain.profile.dto.ProfileListResponseDto;
 import com.example.feeda.security.jwt.JwtPayload;
-import java.util.List;
+import org.springframework.data.domain.Pageable;
 
 public interface FollowsService {
 
@@ -11,7 +11,9 @@ public interface FollowsService {
 
     void unfollow(JwtPayload jwtPayload, Long followingId);
 
-    List<GetProfileResponseDto> findFollowings(Long profileId, JwtPayload jwtPayload);
+    ProfileListResponseDto findFollowingsPage(Long profileId, JwtPayload jwtPayload,
+        Pageable pageable);
 
-    List<GetProfileResponseDto> findFollowers(Long profileId, JwtPayload jwtPayload);
+    ProfileListResponseDto findFollowersPage(Long profileId, JwtPayload jwtPayload,
+        Pageable pageable);
 }


### PR DESCRIPTION
## 상세 내용

- 기존 전체 조회 => 페이지네이션으로 기능 변경
- Profile, follow는 단방향이기 때문에 follow를 통한 조회 후 map을 통해 조회
- API 명세서 수정완료
<br/>

## 주의 사항

- X

<br/>

## 참고 사항

 - @Validated 사용
 - 경진님이 기존에 사용한 PageListDto 이용해서 반환