### PR TITLE
[#31] 댓글 CRUD 기능 구현 및 권한 검증 추가

### DIFF
--- a/src/main/java/com/example/feeda/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/feeda/domain/comment/controller/CommentController.java
@@ -1,0 +1,59 @@
+package com.example.feeda.domain.comment.controller;
+
+import com.example.feeda.domain.comment.dto.CommentResponse;
+import com.example.feeda.domain.comment.dto.CreateCommentRequest;
+import com.example.feeda.domain.comment.dto.UpdateCommentRequest;
+import com.example.feeda.domain.comment.service.CommentService;
+import com.example.feeda.security.jwt.JwtPayload;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Validated
+public class CommentController {
+
+    private final CommentService commentService;
+
+    // 댓글 작성 - 게시글에 대한 댓글 생성
+    @PostMapping("/posts/{postId}/comments")
+    public ResponseEntity<CommentResponse> createComment(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal JwtPayload jwtPayload,
+            @RequestBody CreateCommentRequest request
+    ) {
+        Long profileId = jwtPayload.getProfileId();
+        CommentResponse response = commentService.createComment(postId, profileId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    // 댓글 수정 - 특정 댓글 수정
+    @PutMapping("/comments/{commentId}")
+    public ResponseEntity<CommentResponse> updateComment(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal JwtPayload jwtPayload,
+            @Valid @RequestBody UpdateCommentRequest request
+    ) {
+        Long profileId = jwtPayload.getProfileId();
+        CommentResponse response = commentService.updateComment(commentId, profileId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    // 댓글 삭제 - 특정 댓글 삭제
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<Void> deleteComment(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal JwtPayload jwtPayload
+    ) {
+        Long profileId = jwtPayload.getProfileId();
+        commentService.deleteComment(commentId, profileId);
+        return ResponseEntity.noContent().build();
+    }
+}
+
+

--- a/src/main/java/com/example/feeda/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/example/feeda/domain/comment/dto/CommentResponse.java
@@ -1,0 +1,25 @@
+package com.example.feeda.domain.comment.dto;
+
+import com.example.feeda.domain.comment.entity.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class CommentResponse {
+    private final Long id;
+    private final String content;
+    private final String profileName;
+    private final LocalDateTime createdAt;
+
+    public static CommentResponse from(Comment comment) {
+        return CommentResponse.of(
+                comment.getId(),
+                comment.getContent(),
+                comment.getProfile().getNickname(),
+                comment.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/feeda/domain/comment/dto/CreateCommentRequest.java
+++ b/src/main/java/com/example/feeda/domain/comment/dto/CreateCommentRequest.java
@@ -1,0 +1,12 @@
+package com.example.feeda.domain.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor()
+public class CreateCommentRequest {
+    @NotBlank(message = "내용을 입력해주세요.")
+    private String content;
+}

--- a/src/main/java/com/example/feeda/domain/comment/dto/UpdateCommentRequest.java
+++ b/src/main/java/com/example/feeda/domain/comment/dto/UpdateCommentRequest.java
@@ -1,0 +1,12 @@
+package com.example.feeda.domain.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UpdateCommentRequest {
+    @NotBlank(message = "내용을 입력해주세요.")
+    private String content;
+}

--- a/src/main/java/com/example/feeda/domain/comment/entity/Comment.java
+++ b/src/main/java/com/example/feeda/domain/comment/entity/Comment.java
@@ -32,9 +32,6 @@ public class Comment {
     private Profile profile;
 
     @Column(nullable = false)
-    private String title;
-
-    @Column(nullable = false)
     private String content;
 
     @CreatedDate
@@ -45,10 +42,13 @@ public class Comment {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-    public Comment(Post post, Profile profile, String title, String content) {
+    public Comment(Post post, Profile profile, String content) {
         this.post = post;
         this.profile = profile;
-        this.title = title;
+        this.content = content;
+    }
+
+    public void updateContent(String content) {
         this.content = content;
     }
 }

--- a/src/main/java/com/example/feeda/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/feeda/domain/comment/service/CommentService.java
@@ -1,0 +1,64 @@
+package com.example.feeda.domain.comment.service;
+
+import com.example.feeda.domain.comment.dto.CommentResponse;
+import com.example.feeda.domain.comment.dto.CreateCommentRequest;
+import com.example.feeda.domain.comment.dto.UpdateCommentRequest;
+import com.example.feeda.domain.comment.entity.Comment;
+import com.example.feeda.domain.comment.repository.CommentRepository;
+import com.example.feeda.domain.post.entity.Post;
+import com.example.feeda.domain.post.repository.PostRepository;
+import com.example.feeda.domain.profile.entity.Profile;
+import com.example.feeda.domain.profile.repository.ProfileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final ProfileRepository profileRepository;
+
+    public CommentResponse createComment(Long postId, Long profileId, CreateCommentRequest request) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "게시글이 존재하지 않습니다."));
+        Profile profile = profileRepository.findById(profileId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자가 존재하지 않습니다."));
+
+        Comment comment = new Comment(post, profile, request.getContent());
+        commentRepository.save(comment);
+        return CommentResponse.from(comment);
+    }
+
+    @Transactional
+    public CommentResponse updateComment(Long commentId, Long requesterProfileId, UpdateCommentRequest request) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "댓글이 존재하지 않습니다."));
+
+        if (!comment.getProfile().getId().equals(requesterProfileId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "본인의 댓글만 수정할 수 있습니다.");
+        }
+
+        comment.updateContent(request.getContent());
+        return CommentResponse.from(comment);
+    }
+
+    @Transactional
+    public void deleteComment(Long commentId, Long requesterProfileId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "댓글이 존재하지 않습니다."));
+
+        Long authorId = comment.getProfile().getId();
+        Long postOwnerId = comment.getPost().getProfile().getId();
+
+        if (!authorId.equals(requesterProfileId) && !postOwnerId.equals(requesterProfileId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "삭제 권한이 없습니다.");
+        }
+
+        commentRepository.delete(comment);
+    }
+}


### PR DESCRIPTION
## 상세 내용

- 게시글에 댓글 작성 기능 구현
- 댓글 내용 조회 및 응답 DTO 작성
- 댓글 수정 기능 구현 (작성자만 수정 가능, 내용만 변경)
- 댓글 삭제 기능 구현 (댓글 작성자 또는 게시글 작성자만 삭제 가능)
- 요청자 권한 검증 로직 추가로 보안 강화
- 댓글 엔티티 및 DTO에 유효성 검증 적용

<br/>

## 주의 사항

- 댓글 수정, 삭제 시 권한 검증 로직 확인 필수
- 요청 시 JWT 인증에서 프로필 ID 추출 방식 확인