### PR TITLE
#44 댓글 조회 API 구현 - 특정 게시글 전체 댓글 및 단건 댓글 조회 기능 추가

### DIFF
--- a/src/main/java/com/example/feeda/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/feeda/domain/comment/controller/CommentController.java
@@ -15,6 +15,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
@@ -25,7 +27,7 @@ public class CommentController {
     private final CommentService commentService;
 
     // 댓글 작성
-    @PostMapping("/posts/{postId}/comments")
+    @PostMapping("/comments/posts/{postId}")
     public ResponseEntity<CommentResponse> createComment(
             @PathVariable Long postId,
             @AuthenticationPrincipal JwtPayload jwtPayload,
@@ -35,6 +37,24 @@ public class CommentController {
         CommentResponse response = commentService.createComment(postId, profileId, request);
         return ResponseEntity.ok(response);
     }
+
+    // 댓글 전체 조회 (게시글 기준, 정렬/필터 가능)
+    @GetMapping("/comments/posts/{postId}")
+    public ResponseEntity<List<CommentResponse>> getCommentsByPostId(
+            @PathVariable Long postId,
+            @RequestParam(defaultValue = "latest") String sort // latest 또는 oldest
+    ) {
+        List<CommentResponse> comments = commentService.getCommentsByPostId(postId, sort);
+        return ResponseEntity.ok(comments);
+    }
+
+    // 댓글 단건 조회
+    @GetMapping("/comments/{commentId}")
+    public ResponseEntity<CommentResponse> getCommentById(@PathVariable Long commentId) {
+        CommentResponse response = commentService.getCommentById(commentId);
+        return ResponseEntity.ok(response);
+    }
+
 
     // 댓글 수정
     @PutMapping("/comments/{commentId}")

--- a/src/main/java/com/example/feeda/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/feeda/domain/comment/repository/CommentRepository.java
@@ -3,5 +3,11 @@ package com.example.feeda.domain.comment.repository;
 import com.example.feeda.domain.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    List<Comment> findByPostIdOrderByCreatedAtDesc(Long postId); // 최신순
+
+    List<Comment> findByPostIdOrderByCreatedAtAsc(Long postId);
 }


### PR DESCRIPTION

- 게시글 ID로 댓글 리스트 조회 (최신순/오래된순 정렬 지원)
- 댓글 ID로 단건 댓글 조회 구현
- 존재하지 않는 게시글/댓글 조회 시 404 예외 처리 적용
- CommentResponse DTO 매핑 및 반환